### PR TITLE
Add `.eslintrc` to `files` property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "node test/index.js"
   },
   "files": [
-    "index.js"
+    "index.js",
+    ".eslintrc"
   ],
   "keywords": [
     "eslint",


### PR DESCRIPTION
Resolve error:
```
Error: Cannot read config file: /Users/user/projects/site/www/node_modules/eslint-config-enotes-base/index.js
Error: ENOENT: no such file or directory, open '/Users/user/projects/site/www/node_modules/eslint-config-enotes-base/.eslintrc'
Referenced from: /Users/user/projects/site/www/.eslintrc
```